### PR TITLE
Improve performance of SUMOKBtoTPTPKB

### DIFF
--- a/src/java/com/articulate/sigma/trans/SUMOKBtoTPTPKB.java
+++ b/src/java/com/articulate/sigma/trans/SUMOKBtoTPTPKB.java
@@ -22,7 +22,7 @@ public class SUMOKBtoTPTPKB {
 
     public static HashSet<String> excludedPredicates = new HashSet<>();
 
-    public ArrayList<String> alreadyWrittenTPTPs = new ArrayList<String>();
+    public Set<String> alreadyWrittenTPTPs = new HashSet<>();
 
     // maps TPTP axiom IDs to SUMO formulas
     public static HashMap<String,Formula> axiomKey = new HashMap<>();
@@ -360,8 +360,8 @@ public class SUMOKBtoTPTPKB {
                 }
                 for (String theTPTPFormula : f.theTptpFormulas) {
                     if (!StringUtil.emptyString(theTPTPFormula) &&
-                            !filterAxiom(f,theTPTPFormula,pw) &&
-                            !alreadyWrittenTPTPs.contains(theTPTPFormula)) {
+                            !alreadyWrittenTPTPs.contains(theTPTPFormula) &&
+                            !filterAxiom(f,theTPTPFormula,pw)) {
                         if (debug) System.out.println("SUMOKBtoTPTPKB.writeFile() : writing " + theTPTPFormula);
                         String name = "kb_" + getSanitizedKBname() + "_" + axiomIndex++;
                         axiomKey.put(name,f);


### PR DESCRIPTION
- `filterAxiom` is more resource-intensive than `alreadyWrittenTPTPs.contains` so `alreadyWrittenTPTPs.contains` check is pushed before `filterAxiom`.
- `alreadyWrittenTPTPs` was an ArrayList<String> but it used only to check the presence of formula as `alreadyWrittenTPTPs.contains`. Replaced with HashSet as more efficient for this scenario.

Improves performance of `SUMOKBtoTPTPKB` locally from 15 to 8 min.